### PR TITLE
adds buildtooling for image publishing and release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ venv-dir:
 	@echo $(CURDIR)/$(VENV)
 
 image:
-	@docker build -t inmates .
+	@docker build -t $(PROJECT_NAME) .
 
 image-run:
-	@docker run -it --env PORT=5000 --publish 5000:5000 inmates
+	@docker run -it --env PORT=5000 --publish 5000:5000 $(PROJECT_NAME)
 
 publish:
 	@echo 'TODO (withtwoemms) -- push to heroku here'

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ image-run:
 	@docker run -it --env PORT=5000 --publish 5000:5000 $(PROJECT_NAME)
 
 image-tag:
-	@echo $(PROJECT_NAME):$(shell git tag | head -1)
+	@echo $(PROJECT_NAME):$(shell git tag | tail -1)
 
 image-remote-tag:
 	@echo registry.heroku.com/$(PROJECT_NAME)/web

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,10 @@ clean-venv:
 
 test: $(VENV_PYTHON) $(TESTDIR)
 	@$(VENV_PYTHON) -m unittest discover $(TESTDIR)
+
+targets:
+	@echo
+	@tput bold setaf 2; echo $(shell basename $(CURDIR)); echo
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sed 's/^/  ->  /'
+	@tput sgr0
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ venv-dir:
 	@echo $(CURDIR)/$(VENV)
 
 image:
-	@docker build -t $(PROJECT_NAME) .
+	@docker build -t $(PROJECT_NAME):$(shell git tag | head -1) .
 
 image-run:
 	@docker run -it --env PORT=5000 --publish 5000:5000 $(PROJECT_NAME)

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,23 @@ venv-dir:
 	@echo $(CURDIR)/$(VENV)
 
 image:
-	@docker build -t $(PROJECT_NAME):$(shell git tag | head -1) .
+	@docker build -t $(shell make image-tag) .
 
 image-run:
 	@docker run -it --env PORT=5000 --publish 5000:5000 $(PROJECT_NAME)
 
+image-tag:
+	@echo $(PROJECT_NAME):$(shell git tag | head -1)
+
+image-remote-tag:
+	@echo registry.heroku.com/$(PROJECT_NAME)/web
+
 publish:
-	@echo 'TODO (withtwoemms) -- push to heroku here'
+	@docker tag $(shell make image-tag) $(shell make image-remote-tag)
+	@docker push $(shell make image-remote-tag)
+
+release:
+	@heroku container:release web
 
 build: $(VENV) $(VENV_PYTHON)
 	@$(VENV_PYTHON) setup.py bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ venv:
 venv-dir:
 	@echo $(CURDIR)/$(VENV)
 
-publish: build
-	@$(VENV_PYTHON) setup.py bdist_wheel --skip-build upload --repository nexus
+image:
+	@docker build -t inmates .
+
+publish:
+	@echo 'TODO (withtwoemms) -- push to heroku here'
 
 build: $(VENV) $(VENV_PYTHON)
 	@$(VENV_PYTHON) setup.py bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ venv-dir:
 image:
 	@docker build -t inmates .
 
+image-run:
+	@docker run -it --env PORT=5000 --publish 5000:5000 inmates
+
 publish:
 	@echo 'TODO (withtwoemms) -- push to heroku here'
 


### PR DESCRIPTION
# Summary
* adds `image`, `publish`, and `release` Makefile targets
* also adds some auxiliary targets

# Testing
* ensure you have at least one git tag (run `git tag` to check)
* run `make image-tag` to see an image tag like this `inmates:v0.0.0`
* run `make image-remote-tag` to see the registry name
* we'll forgo the `publish` and `release` testing as this is a privileged action that will ultimately be handled by CI 